### PR TITLE
Fix CAN issue / finally add CAN support #40 #4

### DIFF
--- a/lib/CAN/CANBus.cpp
+++ b/lib/CAN/CANBus.cpp
@@ -57,10 +57,11 @@ void CanBus::init() {
   // TODO: CAN.setPins(int cs, int irq);
 
   // start the CAN bus at 125 kbps
-  if(!CAN.begin(bus_freq)) {
-    Serial.println("Starting CAN failed!");
+  if(CAN.begin(bus_freq)) {
+      Serial.println("CAN initialization succeeded..");
+  } else {
+      Serial.println("CAN initialization failed.");
   }
-  Serial.println("CAN initialized.");
 
   xSemaphoreGive(mutex);
 }

--- a/lib/CAN/CANBus.cpp
+++ b/lib/CAN/CANBus.cpp
@@ -5,59 +5,137 @@
 
 #include <definitions.h>
 
+#include <abstract_task.h>
+#include <definitions.h>
+
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
-#include <CAN_config.h>
-#include <ESP32CAN.h>
+#include <CAN.h>
 
 #include "CANBus.h"
 
+/*
+ * Battery Management System  CANIDs:
+ * BASE = 0x700 (default: 0x600)
+ * +0x0:       BMU heartbeat & serial number
+ * +0x01-0xEF: CMU status, temperature and voltage telemetry (TODO: configure!)
+ * +0xF4:      Pack SOC
+ * +0xF5:      Balance SOC
+ * +0xF6:      Charger Control Information
+ * +0xF7:      Precharge Status, 12V Status
+ * +0xF8:      Min/Max Cell Voltage
+ * +0xF9:      Min/Max Cell Temperature
+ * +0xFA:      Battery Pack Voltage & Current
+ * +0xFB:      Battery Pack Status
+ * +0xFC:      Fan & 12V Supply Status
+ * +0xFD:      Extended Battery Pack Status
+ * 
+ * MPPT IDs: TODO
+ * 
+ * 
+ * !!! BUG: we have to comment out the line: SPI.usingInterrupt(digitalPinToInterrupt(_intPin)); in MCP2515.cpp !!!
+ * 
+ */
+
 void CanBus::re_init() { CanBus::init(); }
+
+void CanBus::exit(){
+  // TODO
+}
+
+string CanBus::getName(void){
+  return std::string("CanBus");
+}
 
 void CanBus::init() {
 
   mutex = xSemaphoreCreateBinary();
 
-  cfg.speed = CAN_SPEED; // MPPT & BMS are both running on 125KBPS by default
-  cfg.tx_pin_id = CAN_TX;
-  cfg.rx_pin_id = CAN_RX;
-  cfg.rx_queue = xQueueCreate(CAN_RX_QUEUE, sizeof(CAN_frame_t));
-  ESP32Can.CANInit();
+  CAN.setClockFrequency(8e6);
+
+  // TODO: CAN.setPins(int cs, int irq);
+
+  // start the CAN bus at 125 kbps
+  if(!CAN.begin(bus_freq)) {
+    Serial.println("Starting CAN failed!");
+  }
+  Serial.println("CAN initialized.");
 
   xSemaphoreGive(mutex);
 }
 
-extern CanBus can;
-void read_can_demo_task(void *pvParameter) {
+void CanBus::read_poll(){
 
-  can.init();
+  // try to parse packet
+  int packetSize = CAN.parsePacket();
 
-  CAN_frame_t rx_frame;
+  if (packetSize) {
+    // received a packet
+    Serial.print("Received ");
+
+    if (CAN.packetExtended()) {
+      Serial.print("extended ");
+    }
+
+    if (CAN.packetRtr()) {
+      // Remote transmission request, packet contains no data
+      Serial.print("RTR ");
+    }
+
+    Serial.print("packet with id 0x");
+    Serial.print(CAN.packetId(), HEX);
+
+    if (CAN.packetRtr()) {
+      Serial.print(" and requested length ");
+      Serial.println(CAN.packetDlc());
+    } else {
+      Serial.print(" and length ");
+      Serial.println(packetSize);
+
+      // only print packet data for non-RTR packets
+      while (CAN.available()) {
+        Serial.print((char)CAN.read());
+      }
+      Serial.println();
+    }
+
+    Serial.println();
+  }
+}
+
+void CanBus::write(uint64_t address, char* data, uint64_t length){
+
+  // send packet: id is 11 bits, packet can contain up to 8 bytes of data
+  CAN.beginPacket(address);
+  for(size_t i = 0; i < length; i++){
+    CAN.write(data[i]);
+  }
+  CAN.endPacket();
+}
+
+void CanBus::write_extended(uint64_t address, char* data, uint64_t length){
+
+  // send extended packet: id is 29 bits, packet can contain up to 8 bytes of data
+  CAN.beginExtendedPacket(address);
+  for(size_t i = 0; i < length; i++){
+    CAN.write(data[i]);
+  }
+  CAN.endPacket();
+}
+
+void CanBus::task() {
 
   while (1) {
     Serial.println("CAN While");
-    xSemaphoreTake(can.mutex, portMAX_DELAY);
+    xSemaphoreTake(mutex, portMAX_DELAY);
 
-    Serial.println("Take Mutex");
-    if (xQueueReceive(can.cfg.rx_queue, &rx_frame, 3 * portTICK_PERIOD_MS) == pdTRUE) {
-      if (rx_frame.FIR.B.FF == CAN_frame_std) {
-        Serial.println("New standard frame");
-      } else {
-        Serial.println("New extended Frame");
-      }
+    read_poll();
 
-      Serial.println("from: ");
-      Serial.println(rx_frame.MsgID);
-      Serial.println("DLC: ");
-      Serial.println(rx_frame.FIR.B.DLC);
+    char hello[10] = { "hello" };
+    write(0x42, hello, strnlen(hello, 10));
 
-      for (int i = 0; i < rx_frame.FIR.B.DLC; i++) {
-        Serial.println(rx_frame.data.u8[i]);
-      }
-      Serial.println("--------------------");
-    }
-    xSemaphoreGive(can.mutex);
+    xSemaphoreGive(mutex);
 
     vTaskDelay(200 / portTICK_PERIOD_MS);
   }

--- a/lib/CAN/CANBus.h
+++ b/lib/CAN/CANBus.h
@@ -2,8 +2,8 @@
 // CAN Bus
 //
 
-#ifndef CANBUS_H
-#define CANBUS_H
+#ifndef SOLAR_CAR_CONTROL_SYSTEM_CANBUS_H
+#define SOLAR_CAR_CONTROL_SYSTEM_CANBUS_H
 
 #include <abstract_task.h>
 #include <definitions.h>
@@ -22,4 +22,4 @@ public:
   void task();
 };
 
-#endif // CANBUS_H
+#endif // SOLAR_CAR_CONTROL_SYSTEM_CANBUS_H

--- a/lib/CAN/CANBus.h
+++ b/lib/CAN/CANBus.h
@@ -2,21 +2,24 @@
 // CAN Bus
 //
 
-#ifndef CAN_H
-#define CAN_H
+#ifndef CANBUS_H
+#define CANBUS_H
 
-#include <CAN_config.h>
-#include <ESP32CAN.h>
-
-void read_can_demo_task(void *pvParameter);
-
-class CanBus {
+#include <abstract_task.h>
+#include <definitions.h>
+class CanBus : public abstract_task {
 private:
+  uint64_t bus_freq = 125E3; // 125kbit/s
 public:
   SemaphoreHandle_t mutex;
-  CAN_device_t cfg;
+  string getName(void);
   void init();
   void re_init();
+  void read_poll();
+  void write(uint64_t address, char* data, uint64_t length);
+  void write_extended(uint64_t address, char* data, uint64_t length);
+  void exit();
+  void task();
 };
 
-#endif // CAN_H
+#endif // CANBUS_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,16 +21,12 @@ platform_packages = framework-arduinoespressif32 @ https://github.com/andreaskus
 ; debug_init_break = tbreak setup
 ; debug_speed=1000
 ; https://youtu.be/psMqilqlrRQ?t=815
-
-;monitor settings (https://docs.platformio.org/en/latest/core/userguide/device/cmd_monitor.html):
-monitor_speed = 115200
-;monitor_port = COM1
+; monitor settings (https://docs.platformio.org/en/latest/core/userguide/device/cmd_monitor.html):
+monitor_speed = 115200 ; monitor_port = COM1
 monitor_flags=
 	--raw
 	--echo
-monitor_filters= send_on_enter
-;monitor_filters= colorize, send_on_enter
-
+monitor_filters= send_on_enter ; monitor_filters= colorize, send_on_enter
 lib_deps =
 	paulstoffregen/OneWire @ ^2.3.5
 	robtillaart/ADS1X15 @ ^0.2.7
@@ -41,5 +37,6 @@ lib_deps =
 	xreef/PCF8574 library @ ^2.2.1
 	adafruit/Adafruit ILI9341 @ ^1.5.6
 	davetcc/IoAbstraction @ ^1.7.5
-  plerup/EspSoftwareSerial @ ^6.12.1
-  miwagner/ESP32CAN@^0.0.1
+  	plerup/EspSoftwareSerial @ ^6.12.1
+  	miwagner/ESP32CAN@^0.0.1
+  	sandeepmistry/CAN @ ^0.3.1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,7 +214,7 @@ void app_main(void) {
   }
   if (CAN_ON) {
     printf(" - read_can_demo_task\n");
-    xTaskCreate(&read_can_demo_task, "can_task", CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE, NULL, 5, NULL);
+    can.create_task();
   }
 
   systemOk = true;


### PR DESCRIPTION
Initial integration of the `CAN` library to either drive the `MCP2515` (tested) or the ESP32 internal chip (untested).

Known issue (has to be manually commented out:

`SPI.usingInterrupt(digitalPinToInterrupt(_intPin));` in `MCP2515.cpp` 