### PR TITLE
Add car speed recuperation

### DIFF
--- a/lib/CarSpeed/CarSpeed.cpp
+++ b/lib/CarSpeed/CarSpeed.cpp
@@ -79,7 +79,8 @@ void CarSpeed::task() {
    * - deceleration/recuperation: Digital to analog converter value representing the recuperation amount: -> 0V: no rec, 5V: max recup
    * -> Note: n case of recup > 0, we should have acceleration 0
    *
-   * TODO: ini file: recuperate on constant speed mode , or just let it roll (i.e. let it roll if the speed is too high is less convenient for the driver, however, it conserves energy since we do not over-regulate) For the moment, we recuperate
+   * TODO: ini file: recuperate on constant speed mode , or just let it roll (i.e. let it roll if the speed is too high is less convenient
+   * for the driver, however, it conserves energy since we do not over-regulate) For the moment, we recuperate
    */
 
   // polling loop
@@ -101,15 +102,14 @@ void CarSpeed::task() {
       // set acceleration & recuperation
       if (output_setpoint >= 0) {
         dac.set_pot(output_setpoint, DAC::pot_chan::POT_CHAN0); // acceleration
-        dac.set_pot(0, DAC::pot_chan::POT_CHAN1); // recuperation
+        dac.set_pot(0, DAC::pot_chan::POT_CHAN1);               // recuperation
       } else {
-        dac.set_pot(0, DAC::pot_chan::POT_CHAN0); // acceleration
+        dac.set_pot(0, DAC::pot_chan::POT_CHAN0);               // acceleration
         dac.set_pot(output_setpoint, DAC::pot_chan::POT_CHAN1); // recuperation
       }
       // TODO: replace dac.set_pot with carControl functions
 
       console << "#--- input_value=" << input_value << ", target_speed=" << target_speed << " ==> deceleration=" << output_setpoint << "\n";
-
     }
     // sleep
     vTaskDelay(sleep_polling_ms / portTICK_PERIOD_MS);

--- a/lib/CarSpeed/CarSpeed.h
+++ b/lib/CarSpeed/CarSpeed.h
@@ -19,17 +19,16 @@ private:
   double Kd = 0.1;
   double speed_increment = 1.0;
   PID pid = PID(&input_value, &output_setpoint, &target_speed, Kp, Ki, Kd, DIRECT);
-  // if (output_setpoint < 0) {
-  //   carState.Acceleration = output_setpoint; // acceleration
-  //   carState.Deceleration = 0;               // deceleration
-  //   console << "#+++ input_value=" << input_value << ", target_speed=" << target_speed << " ==> Acceleration=" << output_setpoint <<
-  //   endl;
-  // } else {
-  //   carState.Acceleration = 0;                // acceleration
-  //   carState.Deceleration = -output_setpoint; // deceleration
-  //   console << "#--- input_value=" << input_value << ", target_speed=" << target_speed << " ==> deceleration=" << output_setpoint <<
-  //   endl;
-  // }
+
+  double input_value;
+  double output_setpoint;
+  double target_speed;
+  double Kp = 2;
+  double Ki = 1;
+  double Kd = 0.1;
+  double speed_increment = 1.0;
+  PID pid = PID(&input_value, &output_setpoint, &target_speed, Kp, Ki, Kd, DIRECT);
+
 public:
   string getName(void) { return "CarSpeed"; };
   void init(void);

--- a/lib/CarSpeed/CarSpeed.h
+++ b/lib/CarSpeed/CarSpeed.h
@@ -20,15 +20,6 @@ private:
   double speed_increment = 1.0;
   PID pid = PID(&input_value, &output_setpoint, &target_speed, Kp, Ki, Kd, DIRECT);
 
-  double input_value;
-  double output_setpoint;
-  double target_speed;
-  double Kp = 2;
-  double Ki = 1;
-  double Kd = 0.1;
-  double speed_increment = 1.0;
-  PID pid = PID(&input_value, &output_setpoint, &target_speed, Kp, Ki, Kd, DIRECT);
-
 public:
   string getName(void) { return "CarSpeed"; };
   void init(void);

--- a/lib/CarState/CarState.cpp
+++ b/lib/CarState/CarState.cpp
@@ -48,6 +48,7 @@ void CarState::init_values() {
   SdCardDetect = false;
 
   TargetSpeed = 0;
+  TargetRecuperation = 0;
   TargetPower = 0;
   DriverInfo = "Acceleration\nstill locked!";
   DriverInfoType = INFO_TYPE::STATUS;

--- a/lib/CarState/CarState.h
+++ b/lib/CarState/CarState.h
@@ -106,15 +106,15 @@ public:
   }
   ~CarState(){};
 
-  // pyhsical car data (measurment values)
+  // physical car data (measurement values)
   int Speed;        // ADC
   int Acceleration; // ADC Steering Wheel
   int Deceleration; // ADC Steering Wheel
-  //#SAVETY#: acceleration lock
+  //#SAFETY#: acceleration lock
   bool AccelerationLocked;  // DSC lock
   bool PaddlesJustAdjusted; // did just padd adjustment: release lock if AccelerationDisplay==0
   int AccelerationDisplay;  // Display Value (-99...+99)
-  //#SAVETY-END#
+  //#SAFETY-END#
 
   bool BatteryOn;      // IO-In
   bool PhotoVoltaicOn; // IO-in
@@ -151,12 +151,13 @@ public:
   DISPLAY_STATUS displayStatus;
   DRIVE_DIRECTION DriveDirection;
   CONSTANT_MODE ConstantMode;
-  bool ConstantModeOn; //#SAVETY#: deceleration unlock const mode
+  bool ConstantModeOn; //#SAFETY#: deceleration unlock const mode
   INDICATOR Indicator;
   bool IndicatorBlink;
   bool SdCardDetect;
 
   float TargetSpeed;
+  float TargetRecuperation;
   float TargetPower;
   string DriverInfo;
   SPEED_ARROW SpeedArrow;


### PR DESCRIPTION
@KarlSchu In my opinion #138 should be resolved here. 

Acceleration is on DAC port 0 (together with an digital I/O indicating forward and reverse driving)

Recuperation is on DAC port1 (direct without PID, since we have no feedback)
