### PR TITLE
Refactor debug to runtime

### DIFF
--- a/include/debugprint.h
+++ b/include/debugprint.h
@@ -9,24 +9,25 @@
 
 extern Console console;
 
-#define DEBUG true
+extern bool debug;
+extern bool debugl2;
+extern bool debugl3;
+
 #define debug_printf(frmt, ...)                                                                                                            \
   do {                                                                                                                                     \
-    if (DEBUG)                                                                                                                             \
+    if (debug)                                                                                                                             \
       console << fmt::sprintf("%-32s:%3d %-36s: " frmt, __FILE__, __LINE__, __func__, __VA_ARGS__);                                        \
   } while (0)
 
-#define DEBUG2 false
 #define debug_printf_l2(frmt, ...)                                                                                                         \
   do {                                                                                                                                     \
-    if (DEBUG2)                                                                                                                            \
+    if (debugl2)                                                                                                                           \
       console << fmt::sprintf("%-32s:%3d %-36s: " frmt, __FILE__, __LINE__, __func__, __VA_ARGS__);                                        \
   } while (0)
 
-#define DEBUG3 false
 #define debug_printf_l3(frmt, ...)                                                                                                         \
   do {                                                                                                                                     \
-    if (DEBUG3)                                                                                                                            \
+    if (debugl3)                                                                                                                           \
       console << fmt::sprintf("%-32s:%3d %-36s: " frmt, __FILE__, __LINE__, __func__, __VA_ARGS__);                                        \
   } while (0)
 

--- a/interfaces/abstract_task.cpp
+++ b/interfaces/abstract_task.cpp
@@ -22,12 +22,13 @@ void abstract_task::init() {
 void abstract_task::sleep() { vTaskDelay(sleep_polling_ms / portTICK_PERIOD_MS); };
 void abstract_task::sleep(int polling_ms) { vTaskDelay(polling_ms / portTICK_PERIOD_MS); };
 
-void abstract_task::create_task(int priority) {
+void abstract_task::create_task(int priority, uint32_t sleep_polling, int stack_size) {
+  sleep_polling_ms = sleep_polling;
   console << " - create task '" << getInfo() << "'...";
 #if WithTaskSuspend == true
-  xTaskCreate((void (*)(void *)) & init_task, getInfo().c_str(), 4096, (void *)this, 1, &xHandle);
+  xTaskCreate((void (*)(void *)) & init_task, getInfo().c_str(), stack_size, (void *)this, 1, &xHandle);
 #else
-  xTaskCreate((void (*)(void *)) & init_task, getInfo().c_str(), 4096, (void *)this, priority, NULL);
+  xTaskCreate((void (*)(void *)) & init_task, getInfo().c_str(), stack_size, (void *)this, priority, NULL);
 #endif
   console << " done.\n";
 };

--- a/interfaces/abstract_task.h
+++ b/interfaces/abstract_task.h
@@ -22,9 +22,8 @@ private:
 #if WithTaskSuspend == true
   TaskHandle_t xHandle;
 #endif
-
 protected:
-  uint32_t sleep_polling_ms = 300;
+  uint32_t sleep_polling_ms;
 
 public:
   virtual string getName(void);
@@ -43,7 +42,7 @@ public:
   void sleep(void);
   void sleep(int polling_ms);
 
-  void create_task(int priority = 1);
+  void create_task(int priority = 1, uint32_t sleep_polling = 300, int stack_size = 4096);
   static void init_task(void *pvParams) { ((abstract_task *)pvParams)->task(); };
 };
 

--- a/lib/CarSpeed/CarSpeed.cpp
+++ b/lib/CarSpeed/CarSpeed.cpp
@@ -37,7 +37,7 @@ void CarSpeed::init() {
   pid = PID(&input_value, &output_setpoint, &target_speed, Kp, Ki, Kd, DIRECT);
   pid.SetMode(AUTOMATIC);
   sleep_polling_ms = 400;
-  console << "[v]" << getName() << " inited.\n";
+  console << "[v]" << getName() << " initialized.\n";
 }
 
 void CarSpeed::exit(void) { set_target_speed(0); }
@@ -75,36 +75,23 @@ void CarSpeed::task() {
   while (1) {
     if (carState.ConstantModeOn && carState.ConstantMode == CONSTANT_MODE::SPEED) {
       // read target speed
-      // input_value = get_current_speed();
       input_value = carState.Speed;
-      target_speed = carState.TargetSpeed;
+      target_speed = carState.TargetSpeed; // can be negative for deceleration
 
       // update pid controller
       pid.Compute();
 
+      // check range
       if (output_setpoint < -DAC_MAX)
         output_setpoint = -DAC_MAX;
       if (output_setpoint > DAC_MAX)
         output_setpoint = DAC_MAX;
 
-      // set acceleration & deceleration // TOOD: check that the value is in range
-      // if (output_setpoint < 0) {
-      //   carState.Acceleration = output_setpoint; // acceleration
-      //   carState.Deceleration = 0;               // deceleration
-      //   console << "#+++ input_value=" << input_value << ", target_speed=" << target_speed << " ==> Acceleration=" << output_setpoint <<
-      //   endl;
-      // } else {
-      //   carState.Acceleration = 0;                // acceleration
-      //   carState.Deceleration = -output_setpoint; // deceleration
-      //   console << "#--- input_value=" << input_value << ", target_speed=" << target_speed << " ==> deceleration=" << output_setpoint <<
-      //   endl;
-      // }
-
-      // set acceleration & deceleration // TOOD: check that the value is in range
+      // set acceleration & deceleration
       if (output_setpoint > 0) {
         dac.set_pot(output_setpoint, DAC::pot_chan::POT_CHAN0); // acceleration
         dac.set_pot(0, DAC::pot_chan::POT_CHAN1);               // deceleration
-        console << "#+++ input_value=" << input_value << ", target_speed=" << target_speed << " ==> Acceleration=" << output_setpoint
+        console << "#+++ input_value=" << input_value << ", target_speed=" << target_speed << " ==> acceleration=" << output_setpoint
                 << "\n";
       } else {
         dac.set_pot(0, DAC::pot_chan::POT_CHAN0);                // acceleration

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,6 +98,10 @@ CarState carState;
 bool startOk = true;
 bool systemOk = false;
 
+bool debug = true;
+bool debugl2 = false;
+bool debugl3 = false;
+
 void app_main(void) {
 
   if (SERIAL_RADIO_ON) {


### PR DESCRIPTION
This PR resolves #87. Right now, the run-time variable is global. We could also make it on a per-class base (i.e. add as class variable, to individually enable/disable debug logs). For now however, I would keep it globally.